### PR TITLE
feat: allow to add css class names to the component

### DIFF
--- a/Lottie.astro
+++ b/Lottie.astro
@@ -10,4 +10,4 @@ export interface Props extends LottieAnimationConfig {
 const { class: cssClass, classList: cssClassList, ...lottieData } = Astro.props;
 ---
 
-<div data-lottie data-lottie-data={JSON.stringify(lottieData)} class:list={[cssClass, ...cssClassList]} />
+<div data-lottie data-lottie-data={JSON.stringify(lottieData)} class:list={[cssClass, ...(cssClassList || [])]} />

--- a/Lottie.astro
+++ b/Lottie.astro
@@ -1,9 +1,13 @@
 ---
+import {AstroBuiltinAttributes} from "astro";
 import type { LottieAnimationConfig } from "./dist/index";
 
-export interface Props extends LottieAnimationConfig {}
+export interface Props extends LottieAnimationConfig {
+  class?: string;
+  'class:list'?: AstroBuiltinAttributes['class:list']
+}
 
-const { ...lottieData } = Astro.props;
+const { class: cssClass, classList: cssClassList, ...lottieData } = Astro.props;
 ---
 
-<div data-lottie data-lottie-data={JSON.stringify(lottieData)}></div>
+<div data-lottie data-lottie-data={JSON.stringify(lottieData)} class:list={[cssClass, ...cssClassList]} />

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ You can either use the `style` attribute or reference a css `class`.
 </div>
 ```
 
+Also, you can use the `class` or `class:list` attribute to add custom css classes directly to the lottie container.
+
+```jsx
+<LottieAnimation src="assets/animation.json" autoplay="visible" class="my-class my-other-class" />
+
+<!-- or -->
+
+<LottieAnimation src="assets/animation.json" autoplay="visible" class:list={["my-class", "my-other-class"]} />
+```
+
+
 ## How `Astro Lottie` works
 ### Player loading
 The lottie player is not bundled within your page. It's asynchronously fetched only when a page contains at least one lottie animation.


### PR DESCRIPTION
It would be useful to be able to modify the components css class. I added this functionality in this PR, so now you can add a css class to the component like: 

```
<LottieAnimation
      src="my-lottie.json"
      class="my-css-class"
/>
```

or ...

```
<LottieAnimation
      src="my-lottie.json"
      class:list=["my-css-class", "other-css-class"]
/>
```
